### PR TITLE
Do not add port if IPv6 address supplied (when DPT-RP1 is in Ethernet…

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -28,7 +28,7 @@ class DigitalPaper():
 
     @property
     def base_url(self):
-        if ":" in self.addr:
+        if ":" in self.addr and self.addr[0] != "[":
             port = ""
         else:
             port = ":8443"


### PR DESCRIPTION
… over USB mode).

The DPT-RP1 uses a IPv6 link-local address for digitalpaper.local. This is an address of the form `fe80::...%usb0` on Linux. With this patch, you can supply the IPv6 address to `--addr` like this:

    dptrp1 --addr [fe80::...%usb0] --client-id ...

And `dptrp1` will work with the DPT-RP1 connected as Ethernet over USB.