### PR TITLE
Add Travis CI setting file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+os:
+  - linux
+dist: trusty
+sudo: false
+python:
+  - "3.6"
+install:
+  - python3 setup.py install
+script:
+  - dptrp1 -h


### PR DESCRIPTION
This setting guarantees that users can install this program by a command: `python3 install .`.

## What is Travis CI?

We can test this program for each commit.  So we will be able to detect immediately when a bug was added and identify the commit in which the bug was added.

See also https://travis-ci.org/

## Example Result

- https://travis-ci.org/y-yu/dpt-rp1-py/builds/363694171