### PR TITLE
Add list-folders command

### DIFF
--- a/bin/dptrp1
+++ b/bin/dptrp1
@@ -19,6 +19,14 @@ def do_list_documents(d):
     for d in data:
         print(d['entry_path'])
 
+def do_list_folders(d, *remote_paths):
+    if remote_paths == ():
+        remote_paths = ('Document',)
+    for p in remote_paths:
+        for o in d.traverse_folder(p):
+            if o['entry_type'] == 'folder':
+                print(o['entry_path'] + '/')
+
 def do_upload(d, local_path, remote_path):
     with open(local_path, 'rb') as fh:
         d.upload(fh, remote_path)
@@ -79,7 +87,7 @@ if __name__ == "__main__":
         "download" : do_download,
         "delete" : do_delete_document,
         "new-folder" : do_new_folder,
-#        "list-folders" : do_list_folders,
+        "list-folders" : do_list_folders,
         "wifi-list": do_wifi_list,
         "wifi-scan": do_wifi_scan,
         "wifi-add": do_add_wifi,

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -227,10 +227,7 @@ class DigitalPaper():
         return data['entry_list']
 
     def download(self, remote_path):
-        encoded_remote_path = quote_plus(remote_path)
-        url = "/resolve/entry/path/{enc_path}".format(enc_path = encoded_remote_path)
-        remote_entry = self._get_endpoint(url).json()
-        remote_id = remote_entry['entry_id']
+        remote_id = self._resolve_object_by_path(remote_path).json()['entry_id']
 
         url = "{base_url}/documents/{remote_id}/file".format(
                 base_url = self.base_url,
@@ -239,21 +236,15 @@ class DigitalPaper():
         return response.content
 
     def delete_document(self, remote_path):
-        encoded_remote_path = quote_plus(remote_path)
-        url = "/resolve/entry/path/{enc_path}".format(enc_path = encoded_remote_path)
-        remote_entry = self._get_endpoint(url).json()
-        remote_id = remote_entry['entry_id']
+        remote_id = self._resolve_object_by_path(remote_path).json()['entry_id']
         url = "/documents/{remote_id}".format(remote_id = remote_id)
         self._delete_endpoint(url)
 
     def upload(self, fh, remote_path):
         filename = os.path.basename(remote_path)
         remote_directory = os.path.dirname(remote_path)
-        encoded_directory = quote_plus(remote_directory)
-        url = "/resolve/entry/path/{enc_dir}".format(enc_dir = encoded_directory)
-        directory_entry = self._get_endpoint(url).json()
 
-        directory_id = directory_entry["entry_id"]
+        directory_id = self._resolve_object_by_path(remote_directory).json()['entry_id']
         info = {
             "file_name": filename,
             "parent_folder_id": directory_id,
@@ -272,11 +263,8 @@ class DigitalPaper():
     def new_folder(self, remote_path):
         folder_name = os.path.basename(remote_path)
         remote_directory = os.path.dirname(remote_path)
-        encoded_directory = quote_plus(remote_directory)
-        url = "/resolve/entry/path/{enc_dir}".format(enc_dir = encoded_directory)
-        directory_entry = self._get_endpoint(url).json()
 
-        directory_id = directory_entry["entry_id"]
+        directory_id = self._resolve_object_by_path(remote_directory).json()['entry_id']
         info = {
             "folder_name": folder_name,
             "parent_folder_id": directory_id
@@ -384,6 +372,11 @@ class DigitalPaper():
 
         r = requests.get(url, verify=False)
         return r.json()["nonce"]
+
+    def _resolve_object_by_path(self, path):
+        enc_path = quote_plus(path)
+        url = "/resolve/entry/path/{enc_path}".format(enc_path = enc_path)
+        return self._get_endpoint(url)
 
 
 # crypto helpers


### PR DESCRIPTION
This implementation depends on #30 and achieved by traversing folders recursively because DPT-RP1 does not seem to provide a function for folder listing. The operation example is as follows:
```
$ dptrp1 ... list-folders
Document/
Document/Drafts/
Document/Note/
Document/Received/
Document/Samples/
```