### PR TITLE
Simpler way to extract credentials on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,40 +53,6 @@ If you get an error, wait a few seconds and try again.  Sometimes it takes two o
 
 If you have already registered on Windows, the Digital Paper app stores the files in _Users/{username}/AppData/Roaming/Sony Corporation/Digital Paper App/_. You'll need the files _deviceid.dat_ and _privatekey.dat_.
 
-#### Extracting the private key and client ID on macOS
-You can also modify the Digital Paper App to write your files to the desktop.
+#### Finding the private key and client ID on macOS
 
-First, [download](https://esupport.sony.com/info/1667/US/EN/) the Digital Paper App. I am going to use the macOS version here but the process should be similar on Windows as the Digital Paper App is just an Electron wrapper around some JavaScript code. You will need to manipulate the application to extract the client identifier (_client\_id_) and the certificate that the application receives from the device upon pairing. 
-
-The main application logic resides in a file called _app.asar_, which can be found at _/Applications/Digital Paper App.app/Contents/Resources/app.asar_ after the installation. Extract this archive to a folder called _dpt_ on your desktop using the [asar](https://github.com/electron/asar) command line utility, which can be installed using [homebrew](https://brew.sh) and npm.
-
-```
-brew install npm
-npm install --global asar
-cd "/Applications/Digital Paper App.app/Contents/Resources"
-asar e app.asar ~/Desktop/dpt 
-```
-
-Surprisingly, the application is nicely organised into different modules that even come with source code comments and readme files. Those modules can be found in _node\_modules/mw-*_ within the _dpt_ folder. To extract the _client\_id_ and the certificate to handle communication with the DPT-RP1, make just one change in _/node\_modules/mw-auth-ctrl/authctrl.js_ by adding a few statements after line 189:
-
-```javascript
-// console.log('attempt to put /auth');
-// console.log(JSON.stringify(authInfo, null, "  "));
-var fs = require('fs');
-var os = require('os');
-var certPath = os.homedir() + '/Desktop/key.pem';
-var clientPath = os.homedir() + '/Desktop/client_id.txt';
-fs.writeFileSync(certPath, data, 'utf-8');
-fs.writeFileSync(clientPath, deviceId, 'utf-8');
-console.log(data);
-console.log(deviceId);
-```
-
-Then use the _asar_ utility again to archive the changes and implement them into the Digital Paper App.
-
-```
-cd "/Applications/Digital Paper App.app"
-sudo asar p ~/Desktop/dpt ./Contents/Resources/app.asar
-```
-
-Now run the Digital Paper App and it will create two files, _client\_id.txt_ and _key.pem_, on the desktop once the pairing is complete.
+If you have already registered on macOS, the Digital Paper app stores the files in _$HOME/Library/Application Support/Sony Corporation/Digital Paper App/_. You'll need the files _deviceid.dat_ and _privatekey.dat_.


### PR DESCRIPTION
You can find them under _$HOME/Library/Application Support/Sony Corporation/Digital Paper App/_