### PR TITLE
Update the name of method '_sign'

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -211,7 +211,7 @@ class DigitalPaper():
     def authenticate(self, client_id, key):
         sig_maker = httpsig.Signer(secret=key, algorithm='rsa-sha256')
         nonce = self._get_nonce(client_id)
-        signed_nonce = sig_maker._sign(nonce)
+        signed_nonce = sig_maker.sign(nonce)
         url = "{base_url}/auth".format(base_url = self.base_url)
         data = {
             "client_id": client_id,


### PR DESCRIPTION
The method attribute `_sign` of Signer in httpsig has been changed to
`sign` recently.