### PR TITLE
Add an option for extracting information of a document

### DIFF
--- a/bin/dptrp1
+++ b/bin/dptrp1
@@ -43,6 +43,11 @@ def do_download(d, remote_path, local_path):
     with open(local_path, 'wb') as f:
         f.write(data)
 
+def do_document_info(d, remote_path):
+    data = d.document_info(remote_path)
+    for key in data:
+        print(key + ": " + data[key])
+
 def do_update_firmware(d, local_path):
     with open(local_path, 'rb') as fwfh:
         d.update_firmware(fwfh)
@@ -106,6 +111,7 @@ if __name__ == "__main__":
         "list-documents" : do_list_documents,
         "upload" : do_upload,
         "download" : do_download,
+        "document-info" : do_document_info,
         "delete" : do_delete_document,
         "new-folder" : do_new_folder,
         "list-folders" : do_list_folders,
@@ -122,18 +128,18 @@ if __name__ == "__main__":
 
     def build_parser():
         p = argparse.ArgumentParser(description = "Remote control for Sony DPT-RP1")
-        p.add_argument('--client-id', 
+        p.add_argument('--client-id',
                 help = "File containing the device's client id",
                 default = deviceid,
                 required = not os.path.isfile(deviceid))
-        p.add_argument('--key', 
+        p.add_argument('--key',
                 help = "File containing the device's private key",
                 default = privatekey,
                 required = not os.path.isfile(privatekey))
-        p.add_argument('--addr', 
+        p.add_argument('--addr',
                 help = "Hostname or IP address of the device")
-        p.add_argument('command', 
-                help = 'Command to run', 
+        p.add_argument('command',
+                help = 'Command to run',
                 choices = sorted(commands.keys()))
         p.add_argument('command_args',
                 help = 'Arguments for the command',

--- a/bin/dptrp1
+++ b/bin/dptrp1
@@ -43,10 +43,20 @@ def do_download(d, remote_path, local_path):
     with open(local_path, 'wb') as f:
         f.write(data)
 
-def do_document_info(d, remote_path):
-    data = d.document_info(remote_path)
-    for key in data:
-        print(key + ": " + data[key])
+def do_list_document_info(d, remote_path = False):
+    if not remote_path:
+        infos = d.list_all()
+        for info in infos:
+            print(info['entry_path'])
+            for key in info:
+                print("    - " + key + ": " + info[key])
+    else:
+        info = d.list_document_info(remote_path)
+        print(info['entry_path'])
+        for key in info:
+            print("    - " + key + ": " + info[key])
+
+
 
 def do_update_firmware(d, local_path):
     with open(local_path, 'rb') as fwfh:
@@ -111,7 +121,7 @@ if __name__ == "__main__":
         "list-documents" : do_list_documents,
         "upload" : do_upload,
         "download" : do_download,
-        "document-info" : do_document_info,
+        "document-info" : do_list_document_info,
         "delete" : do_delete_document,
         "new-folder" : do_new_folder,
         "list-folders" : do_list_folders,

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -247,6 +247,10 @@ class DigitalPaper():
                 return [obj] + functools.reduce(lambda acc, c: traverse(c) + acc, children[::-1], [])
         return traverse(self._resolve_object_by_path(remote_path).json())
 
+    def document_info(self, remote_path):
+        remote_info = self._resolve_object_by_path(remote_path).json()
+        return remote_info
+
     def download(self, remote_path):
         remote_id = self._resolve_object_by_path(remote_path).json()['entry_id']
 

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -247,7 +247,7 @@ class DigitalPaper():
                 return [obj] + functools.reduce(lambda acc, c: traverse(c) + acc, children[::-1], [])
         return traverse(self._resolve_object_by_path(remote_path).json())
 
-    def document_info(self, remote_path):
+    def list_document_info(self, remote_path):
         remote_info = self._resolve_object_by_path(remote_path).json()
         return remote_info
 


### PR DESCRIPTION
This commit adds `document-info` option, which is for extracting
specifid informations of a document. The informations are useful for
adding new features like version control.

Output example
--------------
modified_date: 2019-05-18T15:42:47Z
entry_id: ae94e958-cfc7-405e-9cd5-fb45248b8066
document_type: normal
created_date: 2019-05-18T15:42:47Z
entry_type: document
current_page: 1
entry_name: Welcome, 2019.pdf
title:
ext_id:
file_revision: fb45248b8066.1.0
entry_path: Document/Work/Welcome, 2019.pdf
total_page: 4
parent_folder_id: 0aa34ff1-382c-4054-a8a4-a2d676cf1637
mime_type: application/pdf
file_size: 77634
document_source: b1b62331-4b47-4c09-a263-5c34bd593ff5
is_new: true

Signed-off-by: Yunjae Lee <lyj7694@gmail.com>