### PR TITLE
Add an option for folder deletion

### DIFF
--- a/bin/dptrp1
+++ b/bin/dptrp1
@@ -53,6 +53,9 @@ def do_delete_document(d, remote_path):
 def do_new_folder(d, remote_path):
     d.new_folder(remote_path)
 
+def do_delete_folder(d, remote_path):
+    d.delete_folder(remote_path)
+
 def do_wifi_list(d):
     data = d.wifi_list()
     print(json.dumps(data, indent=2))
@@ -108,6 +111,7 @@ if __name__ == "__main__":
         "download" : do_download,
         "delete" : do_delete_document,
         "new-folder" : do_new_folder,
+        "delete-folder" : do_delete_folder,
         "list-folders" : do_list_folders,
         "wifi-list": do_wifi_list,
         "wifi-scan": do_wifi_scan,

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -293,6 +293,15 @@ class DigitalPaper():
 
         r = self._post_endpoint("/folders2", data=info)
 
+    def delete_folder(self, remote_path):
+        folder_name = os.path.basename(remote_path)
+        remote_directory = os.path.dirname(remote_path)
+
+        directory_id = self._resolve_object_by_path(remote_path).json()['entry_id']
+        url = "/folders/{directory_id}".format(directory_id = directory_id)
+
+        r = self._delete_endpoint(url)
+
     ### Wifi
     def wifi_list(self):
         data = self._get_endpoint('/system/configs/wifi_accesspoints').json()


### PR DESCRIPTION
The `delete` command only works for documents, not for folders. This
commit adds `delete-folder` command.

Signed-off-by: Yunjae Lee <lyj7694@gmail.com>