### PR TITLE
Add mDNS auto-discovery

### DIFF
--- a/bin/dptmount
+++ b/bin/dptmount
@@ -58,8 +58,10 @@ import anytree
 
 class DptTablet(LoggingMixIn, Operations):
 
-    def __init__(self, dpt_ip_address=None, dpt_key=None, dpt_client_id=None, uid=None, gid=None):
+    def __init__(self, dpt_ip_address=None, dpt_serial_number=None,
+                 dpt_key=None, dpt_client_id=None, uid=None, gid=None):
         self.dpt_ip_address = dpt_ip_address
+        self.dpt_serial_number = dpt_serial_number
         self.dpt_key = os.path.expanduser(dpt_key)
         self.dpt_client_id = os.path.expanduser(dpt_client_id)
         self.uid = uid
@@ -90,7 +92,7 @@ class DptTablet(LoggingMixIn, Operations):
                                     st_nlink=2), )
 
     def __authenticate__(self):
-        self.dpt = DigitalPaper(self.dpt_ip_address)
+        self.dpt = DigitalPaper(self.dpt_ip_address, self.dpt_serial_number)
 
         with open(self.dpt_client_id) as fh:
             client_id = fh.readline().strip()
@@ -327,7 +329,7 @@ if __name__ == '__main__':
 
     # Read YAML config if found
     if os.path.isfile(args.config):
-        config = yaml.load(open(args.config, 'r'))
+        config = yaml.safe_load(open(args.config, 'r'))
     else:
         print("Config file not found")
         sys.exit(-1)
@@ -335,7 +337,8 @@ if __name__ == '__main__':
     # config
     cfgargs = config['dptrp1']
     params = dict(
-        dpt_ip_address = cfgargs['addr'],
+        dpt_ip_address = cfgargs.get('addr', None),
+        dpt_serial_number = str(cfgargs.get('id', None)),
         dpt_client_id = cfgargs['client-id'],
         dpt_key = cfgargs['key'],
         uid = os.getuid(),

--- a/bin/dptrp1
+++ b/bin/dptrp1
@@ -181,9 +181,13 @@ def build_parser():
     p.add_argument('--key',
             help = "File containing the device's private key",
             default = privatekey)
-    p.add_argument('--addr',
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument('--addr',
             help = "Hostname or IP address of the device",
-            required = True)
+            required = False, default=None)
+    group.add_argument('--id',
+                   help = "Device serial number for auto discovery",
+                   default = None)
     p.add_argument('command',
             help = 'Command to run',
             choices = sorted(commands.keys()))
@@ -194,7 +198,7 @@ def build_parser():
 
 def main():
     args = build_parser().parse_args()
-    dp = DigitalPaper(addr = args.addr)
+    dp = DigitalPaper(addr=args.addr, id=args.id)
     if args.command == "register":
         do_register(dp, args.key, args.client_id)
         return

--- a/setup.json
+++ b/setup.json
@@ -21,7 +21,8 @@
         "urllib3>=1.22",
         "pyyaml",
         "anytree",
-        "fusepy"
+        "fusepy",
+        "zeroconf"
     ],
     "scripts": [
         "dptrp1",


### PR DESCRIPTION
mDNS auto-discovery for "_digitalpaper._tcp" using zeroconf package.
Uses serial number matching as well in case of multiple dpt-rp1s on
local network.

--id parameter is added to the commandline interface and id field is
added to dptmount configuration.