### PR TITLE
Improve detection of existing authentication files from Digital Paper App

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -20,15 +20,22 @@ from Crypto.Hash import SHA256
 from Crypto.Hash.HMAC import HMAC
 from Crypto.Cipher import AES
 from Crypto.PublicKey import RSA
+from pathlib import Path
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-def find_auth_files():
-    from pathlib import Path
+def get_default_auth_files():
+    """Get the default path where the authentication files for connecting to DPT-RP1 are stored"""
     config_path = os.path.join(Path.home(), ".dpapp")
     os.makedirs(config_path, exist_ok=True)
     deviceid = os.path.join(config_path, "deviceid.dat")
     privatekey = os.path.join(config_path, "privatekey.dat")
+    
+    return deviceid, privatekey
+
+def find_auth_files():
+    """Search for authentication files for connecting to DPT-RP1, both in default path and in paths from Sony's Digital Paper App"""
+    deviceid, privatekey = get_default_auth_files()
     
     if not os.path.exists(deviceid) or not os.path.exists(privatekey):
         # Could not find our own auth-files. Let's see if we can find any auth files created by Sony's Digital Paper App

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -28,7 +28,7 @@ def find_auth_files():
     config_path = os.path.join(Path.home(), ".dpapp")
     if sys.platform.startswith('darwin'):
             config_path = os.path.join(Path.home(), "Library/Application Support/Sony Corporation/Digital Paper App")
-    elif sys.platform.startswith('windows'):
+    elif sys.platform.startswith('win'):
             config_path = os.path.join(Path.home(), "AppData/Roaming/Sony Corporation/Digital Paper App")
     os.makedirs(config_path, exist_ok=True)
     deviceid = os.path.join(config_path, "deviceid.dat")

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -33,6 +33,20 @@ def find_auth_files():
     os.makedirs(config_path, exist_ok=True)
     deviceid = os.path.join(config_path, "deviceid.dat")
     privatekey = os.path.join(config_path, "privatekey.dat")
+    
+    if not os.path.exists(deviceid) or not os.path.exists(privatekey):
+        # In some (all?) cases, the  actual .dat-files created by the Digital Paper App are not located directly in config_path,
+        # but instead inside of a sub-folder.
+        # Let's do a quick glob-match to see if we can locate them
+        deviceid_matches = glob(os.path.join(config_path,"DigitalPaperApp", "**/deviceid.dat"), recursive=True)
+        privatekey_matches = glob(os.path.join(config_path,"DigitalPaperApp", "**/privatekey.dat"), recursive=True)
+
+        if deviceid_matches and privatekey_matches:
+            # Found a match. Selecting the first file for each for now. 
+            # This might not be correct if the user has several devices with their own keys. Should ideally be configurable
+            deviceid = deviceid_matches[0]
+            privatekey = privatekey_matches[0]
+
     return deviceid, privatekey
 
 class DigitalPaperException(Exception):

--- a/setup.json
+++ b/setup.json
@@ -13,7 +13,8 @@
         "Sreepathi Pai",
         "Jochen Schroeder",
         "Alexander Fuchs",
-        "Xiang Ji"
+        "Xiang Ji",
+        "Håkon J. D. Johnsen"
     ],
     "emails": [
         "jan-gerd.tenberge@uni-muenster.de",
@@ -25,7 +26,8 @@
         "sree314@gmail.com",
         "jochen.schroeder@chalmers.se",
         "alex.fu27@gmail.com",
-        "hi@xiangji.me"
+        "hi@xiangji.me",
+        "hakon.j.d.johnsen@ntnu.no"
     ],
     "namespace_packages": [
 


### PR DESCRIPTION
This PR improves the detection of authentication files created by the Digital Paper App with the following two changes:

- Fix a bug in platform detection when selecting which path to search for authentication files
- Also detect authentication files stored in sub-directories of the selected directory. (Where Sony's Digital Paper App stores them, at least the current version of the app on Windows.)

### Warning: ###
This change is not backward compatible. If someone has already registered their device on Windows using dpt-rp1-py, the authentication files will have been stored in `~/.dpapp/` due to the platform detection bug fixed in this pull request. After applying this pull request, only `~/AppData/Roaming/Sony Corporation/Digital Paper App` will be searched for authentication files on Windows.

If backward compatibility is important, we could for instance:
- Skip the platform detection logic, and just look for authentication files in the small set of known possible paths, defaulting to `~/.dpapp/` if nothing else is found. This used to be how it worked, but it was removed in commit 38d150fee027af5ef68fde092da512fda353abac. I like this approach, but have not implemented it in case there was a good reason for going away from this behaviour in the earlier commit.
- Use platform detection to choose where to look for authentication files created by the Digital Paper App, but fall back to `~/.dpapp/` (or some other folder) if the Digital Paper App has not created authentication files.

What is your preference on this? Let me know if you want me to update the pull with one of these changes, or if you have some other suggestion.