### PR TITLE
Improve synchronization

### DIFF
--- a/dptrp1/cli/dptrp1.py
+++ b/dptrp1/cli/dptrp1.py
@@ -189,6 +189,11 @@ def build_parser():
     p.add_argument('--serial',
             help = "Device serial number for auto discovery. Auto discovery only works for some minutes after the Digital Paper's Wi-Fi setting is switched on.",
             default = None)
+    p.add_argument('--yes','-y',
+            help = "Automatically answer yes to confirmation prompts, for running non-interactively.",
+            action = 'store_true',
+            dest = 'assume_yes',
+            default = False)
     p.add_argument('command',
             help = 'Command to run',
             choices = sorted(commands.keys()))
@@ -199,7 +204,7 @@ def build_parser():
 
 def main():
     args = build_parser().parse_args()
-    dp = DigitalPaper(addr=args.addr, id=args.serial)
+    dp = DigitalPaper(addr=args.addr, id=args.serial, assume_yes=args.assume_yes)
     if args.command == "register":
         # When registering the device, we default to storing auth files in our own configuration directory
         default_deviceid, default_privatekey = get_default_auth_files()

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -334,10 +334,15 @@ class DigitalPaper():
         response = self._get_endpoint(f"/folders/{folder_id}/entries")
         return response.json()['entry_list']
 
-    def traverse_folder(self, remote_path):
+    def traverse_folder(self, remote_path,fields=[]):
         # In most cases, the request overhead of traversing folders is larger than the overhead of
         # requesting all info. So let's just request all info and filter for remote_path on our side
-        all_entries = self.list_all()
+        if fields:
+            field_query = '&fields=' + ",".join(fields)
+        else:
+            field_query = ''
+        all_entries = self._get_endpoint(f'/documents2?entry_type=all'+field_query).json()['entry_list']
+
         return list(filter(lambda e: e["entry_path"].startswith(remote_path),all_entries))
 
     def list_document_info(self, remote_path):
@@ -459,7 +464,7 @@ class DigitalPaper():
         self.set_datetime()
         self.new_folder(remote_folder)
         print("Looking for changes on device... ",end="",flush=True)
-        remote_info = self.traverse_folder(remote_folder)
+        remote_info = self.traverse_folder(remote_folder,fields=['entry_path','modified_date','entry_type'])
         print("done")
 
         # Syncing will require different comparions between local and remote paths.
@@ -609,7 +614,7 @@ class DigitalPaper():
         progress_bar.close()
 
         print("Refreshing file information... ",end="",flush=True)
-        remote_info = self.traverse_folder(remote_folder)
+        remote_info = self.traverse_folder(remote_folder,fields=['entry_path','modified_date','entry_type'])
         print("done")
         self.sync_checkpoint(local_folder, remote_info)
 

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -628,8 +628,8 @@ class DigitalPaper():
 
         print("Refreshing file information... ",end="",flush=True)
         remote_info = self.traverse_folder(remote_folder,fields=['entry_path','modified_date','entry_type'])
-        print("done")
         self.sync_checkpoint(local_folder, remote_info)
+        print("done")
 
     def load_checkpoint(self, local_folder):
         checkpoint_file = os.path.join(local_folder, ".sync")

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -333,15 +333,10 @@ class DigitalPaper():
         return response.json()['entry_list']
 
     def traverse_folder(self, remote_path):
-        def traverse(obj):
-            if obj['entry_type'] == 'document':
-                return [obj]
-            else:
-                children = self \
-                  ._get_endpoint("/folders/{remote_id}/entries2".format(remote_id = obj['entry_id'])) \
-                  .json()['entry_list']
-                return [obj] + functools.reduce(lambda acc, c: traverse(c) + acc, children[::-1], [])
-        return traverse(self._resolve_object_by_path(remote_path))
+        # In most cases, the request overhead of traversing folders is larger than the overhead of
+        # requesting all info. So let's just request all info and filter for remote_path on our side
+        all_entries = self.list_all()
+        return list(filter(lambda e: e["entry_path"].startswith(remote_path),all_entries))
 
     def list_document_info(self, remote_path):
         remote_info = self._resolve_object_by_path(remote_path)

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -486,7 +486,7 @@ class DigitalPaper():
 
         for f in checkpoint_info:
             path = normalize_path(f["entry_path"])
-            if 'modified_date' in f:
+            if path.startswith(remote_folder) and 'modified_date' in f:
                 modification_time = datetime.strptime(f['modified_date'], '%Y-%m-%dT%H:%M:%SZ')
                 file_data[path]["checkpoint_time"] = modification_time
 

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -426,7 +426,12 @@ class DigitalPaper():
         return self.folder_list
 
     def download_file(self, remote_path, local_path):
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        local_folder = os.path.dirname(local_path)
+        # Make sure that local_folder exists so that we can write data there.
+        # If local_path is just a filename, local_folder will be '', and
+        # we won't need to create any directories.
+        if local_folder != '':
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
         data = self.download(remote_path)
         with open(local_path, 'wb') as f:
             f.write(data)

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -530,6 +530,30 @@ class DigitalPaper():
             local_path = os.path.join(local_folder, remote_path)
             if not os.path.exists(unicodedata.normalize("NFC", local_path)):
                 to_delete_remote.append(c)
+        
+        print("Ready to sync")
+        print("")
+        if to_delete_local:
+            print(f"{len(to_delete_local):4d} files will be DELETED locally")
+        if to_delete_remote:
+            print(f"{len(to_delete_remote):4d} files will be DELETED from device")
+        if to_upload:
+            print(f"{len(to_upload):4d} files will be UPLOADED to device")
+        if to_download:
+            print(f"{len(to_download):4d} files will be DOWNLOADED from device")
+
+        if not (to_delete_local or to_delete_remote or to_upload or to_download):
+            print("All files are in sync. Exiting.")
+            return
+
+        # Conferm that the user actually wants to perform the actions that
+        # have been prepared.
+        print("")
+        confirm = ""
+        while confirm not in ('y', 'yes'):
+            confirm = input(f"Proceed (y/n)? ")
+            if confirm in ('n', 'no'):
+                return
 
         # Apply changes in remote to local
         for file_info in to_download:

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -581,14 +581,14 @@ class DigitalPaper():
                 to_delete_local.append(filename)
         
         if missing_checkpoint_files:
-            print("\nWarning: The following files exist both locally and on the DPT-RP1, but do not seem to have been synchronized using this tool:")
+            print("\nWarning: The following files exist both locally and on the DPT, but do not seem to have been synchronized using this tool:")
 
             max_print = 20 # Let's only print the first max_print filenames to avoid completely flooding 
                            # stdout with unusable information if missing metadata means that this happens 
                            # to all files in the user's library
-            print("  " + "\n  ".join(missing_checkpoint_files[:max_print]))
+            print("\t" + "\n\t".join(missing_checkpoint_files[:max_print]))
             if len(missing_checkpoint_files) > max_print:
-                print(f"  ... and {len(missing_checkpoint_files)-max_print} additional files")
+                print(f"\t... and {len(missing_checkpoint_files)-max_print} additional files")
             print("The files will be assumed to be identical.\n")
         
         # Just syncing the files will automatically create the necessary folders to store the given files, but it won't sync empty folders,

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -664,7 +664,13 @@ class DigitalPaper():
             local_path = Path(local_folder) / relative_path
             if os.path.exists(local_path):
                 tqdm.write("X " + str(local_path))
-                os.rmdir(local_path)
+                try: 
+                    os.rmdir(local_path)
+                except OSError as e:
+                    if e.errno == 39:
+                        tqdm.write(f"WARNING: The folder {local_path} is not empty and will not be deleted.")
+                    else:
+                        raise
             progress_bar.update()
 
         for remote_path in folders_to_create_local:

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -556,14 +556,10 @@ class DigitalPaper():
         print("")
         print("Ready to sync")
         print("")
-        if to_delete_local:
-            print(f"{len(to_delete_local):4d} files will be DELETED locally")
-        if to_delete_remote:
-            print(f"{len(to_delete_remote):4d} files will be DELETED from device")
-        if to_upload:
-            print(f"{len(to_upload):4d} files will be UPLOADED to device")
-        if to_download:
-            print(f"{len(to_download):4d} files will be DOWNLOADED from device")
+        actions = [(to_delete_local,"DELETED locally"),(to_delete_remote,'DELETED from device'),(to_upload,'UPLOADED to device'),(to_download,'DOWNLOADED from device')]
+        for file_list,description in actions:
+            if file_list:
+                print(f"{len(file_list):4d} files will be {description}")
 
         if not (to_delete_local or to_delete_remote or to_upload or to_download):
             print("All files are in sync. Exiting.")
@@ -574,9 +570,17 @@ class DigitalPaper():
         print("")
         confirm = ""
         while confirm not in ('y', 'yes'):
-            confirm = input(f"Proceed (y/n)? ")
+            confirm = input(f"Proceed (y/n/?)? ")
             if confirm in ('n', 'no'):
                 return
+            if confirm in ('?','list','l'):
+                for file_list,description in actions:
+                    if file_list:
+                        print("")
+                        print(f"The following files will be {description}:")
+                        print("\t" + "\n\t".join(file_list))
+                        print("")
+                    
         
         # Syncing can potentially take some time, so let's display a progress bar
         # to give the user some idea about the progress.

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -111,7 +111,7 @@ class LookUpDPT:
             return self.addr
 
 class DigitalPaper():
-    def __init__(self, addr=None, id=None):
+    def __init__(self, addr=None, id=None, assume_yes=False):
         if addr:
             self.addr = addr
             if id:
@@ -122,6 +122,8 @@ class DigitalPaper():
 
         self.session = requests.Session()
         self.session.verify = False # disable ssl certificate verification
+
+        self.assume_yes = assume_yes # Whether to disable interactive prompts (currently only in sync())
 
     @property
     def base_url(self):
@@ -644,7 +646,7 @@ class DigitalPaper():
         # have been prepared.
         print("")
         confirm = ""
-        while confirm not in ('y', 'yes'):
+        while not (confirm in ('y', 'yes') or self.assume_yes):
             confirm = input(f"Proceed (y/n/?)? ")
             if confirm in ('n', 'no'):
                 return

--- a/setup.json
+++ b/setup.json
@@ -44,7 +44,8 @@
         "pyyaml",
         "anytree",
         "fusepy",
-        "zeroconf"
+        "zeroconf",
+        "tqdm"
     ],
     "entry_points": {
         "console_scripts": [


### PR DESCRIPTION
Hi Jan-Gerd,

This PR contains some improvements to the sync command. 

**Sync confirmation**
Commit e98e87a8e25862c7abf5332ddde9d76f51acf514 shows the user a summary of the number of files that will be transferred/deleted. In this way, the user will hopefully notice if he has made an error, so that the action (and potential data loss) can be aborted. 

A few things to think about here:
 - This change is not fully backward compatible, since syncing is no longer non-interactive. If the user has set up a cron job to sync automatically, this will no longer work. However, I think it is not too unreasonable to break backward compatibility since the sync functionality is new and experimental. Adding a command-line flag for noninteractive mode might be useful for cron jobs and the like, but I did not prioritize it for now.
 - The confirmation check happens in the dptrp1 module, not in the CLI module. It seems like you have a fairly clean separation between the library and the CLI, and this breaks that separation to a certain extent. I personally don't think it is a big problem, but feel free to let me know if you would like it to be organized differently.

**Syncing on Windows**
Commit 8a687742a5d62d5ad086a4819695513302f68ced normalizes the directory separator being used in the sync logic, to fix syncing on Windows. This is done using simple string replacement. It would probably be cleaner to do it all using pathlib or something, but this approach was a quick and easy fix. Tested on Windows and Linux.

**Progress bar**
Commit d747b4a4e4548088801fb658e5b808cd2bf6bb81 shows some additional progress information, including a tqdm progress bar. This adds an extra dependency, but tqdm is a popular library and I think the improved usability is worth the extra dependency.

Feel free to let me know if you want any of these things to be done differently. The changes are atomic, so you can also cherry-pick just 1 or 2 if you don't want to merge them all.

Best,
Håkon