### PR TITLE
Add small tip for WiFi connexion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that the root path for DPT-RP1 is `Document/`. Example command to download 
 The DPT-RP1 uses SSL encryption to communicate with the computer.  This requires registering the DPT-RP1 with the computer, which results in two pieces of information -- the client ID and the key file -- that you'll need to run the script. You can get this information in three ways.
 
 #### Registering without the Digital Paper App
-This method requires your DPT-RP1 and your computer to be on the same network segment via WiFi, Bluetooth or a USB connection. The USB connection works on Windows and macOS but may not work on a Linux machine.
+This method requires your DPT-RP1 and your computer to be on the same network segment via WiFi, Bluetooth or a USB connection. The USB connection works on Windows and macOS but may not work on a Linux machine. If your WiFi network is not part of the "Saved Network List" (for example if you don't have the app), you can still use the DPT-RP1 as a WiFi access point and connect your computer to it.
 
 ```
 dptrp1 register


### PR DESCRIPTION
I was a bit lost at first since I could not connect my device to my WiFi network (you need the app for that, and linux users cannot have it). USB was not working either.

But it's still possible to get both devices connected over WiFi by using the reader as a hotspot, so I added a short description in the README hoping that it can help future users.

Thank you so much for your work!