### PR TITLE
Fix #89

### DIFF
--- a/dptrp1/cli/dptmount.py
+++ b/dptrp1/cli/dptmount.py
@@ -288,7 +288,14 @@ class DptTablet(LoggingMixIn, Operations):
         parent = self._map_local_remote(dpath)
         remote_path = os.path.join(parent.remote_path, fname)
         self.dpt.upload(stream, remote_path)
-        node = self._add_remote_path_to_tree(parent, remote_path)
+
+        duplicate = anytree.search.find(parent, filter_=lambda node, remote_path=remote_path: node.remote_path == remote_path)
+        if duplicate is None:
+            node = self._add_remote_path_to_tree(parent, remote_path)
+        else:
+            item = self.dpt._resolve_object_by_path(remote_path)
+            duplicate.item = item
+            duplicate.lstat = self._get_lstat(item)
         #self.files.pop(path)
         return
     


### PR DESCRIPTION
I've made a small patch to fix #89.  
It updates the information of a file if it has duplicate in file tree, instead of adding it to the tree.

I'm not familiar with FUSE, so please correct the patch if it does something wrong.