### PR TITLE
for mount filesys, added addr None check and path spec in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This Repository contains a `dptmount` script to mount the Digital Paper as a use
 - On Linux, you may need to install libfuse.
 
 ### How to use 
-Create a yaml file with configuration details at _~/.config/dpt-rp1.conf_. You must specify either an address (with `addr`) or a Device ID (with `serial`). Everything else is optional. All entries must be strings, the serial number must be wrapped in quotation marks.
+Create a yaml file with configuration details at _~/.config/dpt-rp1.conf_. You must specify either an address (with `addr`) or a Device ID (with `serial`). All entries must be strings, the serial number must be wrapped in quotation marks.
 
 ```
 dptrp1:
@@ -62,8 +62,8 @@ dptrp1:
   client-id: ~/.config/dpt/deviceid.dat
   key: ~/.config/dpt/privatekey.dat
 ```
-
-Mount the Digital Paper to a directory with `dptmount /my/mountpoint/`. 
+If you register with `dptrp1 register` command, the client-id shall be $HOME/.dpapp/deviceid.dat, and key shall be $HOME/.dpapp/privatekey.dat.
+Mount the Digital Paper to a directory with `dptmount --config ~/.config/dpt-rp1.conf /mnt/mountpoint`
 
 #### Finding the private key and client ID on Windows
 

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -122,7 +122,7 @@ class DigitalPaper():
 
     @property
     def base_url(self):
-        if ":" in self.addr and self.addr[0] != "[":
+        if self.addr and ":" in self.addr and self.addr[0] != "[":
             port = ""
         else:
             port = ":8443"


### PR DESCRIPTION
"Everything else is optional" was misleading. 
I removed `addr` field and got run-time error [here](https://github.com/janten/dpt-rp1-py/blob/2f25a86d1e033091252186ece23b070f07a73032/dptrp1/dptrp1.py#L103), I guess there should probably be a None check? 

The default paths for client-id and key seem not what's in readme according to [find_authpath](https://github.com/janten/dpt-rp1-py/blob/2f25a86d1e033091252186ece23b070f07a73032/dptrp1/dptrp1.py#L34) method, which has caused confusion for new users.