### PR TITLE
fix install encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except Exception as e:
 
 
 def readme():
-    with open(os.path.join(DIRECTORY, "README.md")) as f:
+    with open(os.path.join(DIRECTORY, "README.md"), encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Fixes #117 

apply solution suggested in #117, and it worked after adding `encoding='utf-8'`
