### PR TITLE
Prefixed root folder 'Document' if remote path does not contains one.

### DIFF
--- a/dptrp1/cli/dptrp1.py
+++ b/dptrp1/cli/dptrp1.py
@@ -11,6 +11,7 @@ import re
 from pathlib import Path
 from dptrp1.dptrp1 import DigitalPaper, find_auth_files, get_default_auth_files
 
+ROOT_FOLDER = 'Document'
 
 def do_screenshot(d, filename):
     """
@@ -52,7 +53,7 @@ def do_upload(d, local_path, remote_path=""):
     Will upload to Document/ if only the local path is specified.
     """
     if not remote_path:
-        remote_path = "Document/" + os.path.basename(local_path)
+        remote_path = ROOT_FOLDER + "/" + os.path.basename(local_path)
     d.upload_file(local_path, remote_path)
 
 def do_upload_template(d, local_path, template_name=''):
@@ -80,7 +81,7 @@ def do_download(d, remote_path, local_path):
         f.write(data)
 
 
-def do_list_document_info(d, remote_path=False):
+def do_list_document_info(d, remote_path=''):
     """
     Print metadata about a document on the device.
     If no path is given, information is printed for every document on the device.
@@ -92,7 +93,7 @@ def do_list_document_info(d, remote_path=False):
             for key in info:
                 print("    - " + key + ": " + info[key])
     else:
-        info = d.list_document_info(remote_path)
+        info = d.list_document_info(add_prefix(remote_path))
         print(info["entry_path"])
         for key in info:
             print("    - " + key + ": " + info[key])
@@ -116,15 +117,17 @@ def do_update_firmware(d, local_path):
     with open(local_path, "rb") as fwfh:
         d.update_firmware(fwfh)
 
+def add_prefix(remote_path: str) -> str:
+    return remote_path if remote_path.startswith(ROOT_FOLDER) else f'{ROOT_FOLDER}/{remote_path}'
 
 def do_delete_document(d, remote_path):
-    d.delete_document(remote_path)
+    d.delete_document(add_prefix(remote_path))
 
 def do_delete_template(d,remote_path):
     d.delete_template(remote_path)
 
 def do_delete_folder(d, remote_path):
-    d.delete_folder(remote_path)
+    d.delete_folder(add_prefix(remote_path))
 
 
 def do_sync(d, local_path, remote_path="Document"):
@@ -140,7 +143,7 @@ def do_sync(d, local_path, remote_path="Document"):
 
 
 def do_new_folder(d, remote_path):
-    d.new_folder(remote_path)
+    d.new_folder(add_prefix(remote_path))
 
 
 def do_wifi_list(d):

--- a/dptrp1/cli/dptrp1.py
+++ b/dptrp1/cli/dptrp1.py
@@ -54,7 +54,7 @@ def do_upload(d, local_path, remote_path=""):
     """
     if not remote_path:
         remote_path = ROOT_FOLDER + "/" + os.path.basename(local_path)
-    d.upload_file(local_path, remote_path)
+    d.upload_file(local_path, add_prefix(remote_path))
 
 def do_upload_template(d, local_path, template_name=''):
     """
@@ -99,7 +99,7 @@ def do_list_document_info(d, remote_path=''):
             print("    - " + key + ": " + info[key])
 
 
-def do_dispay_document(d, remote_path, page=1):
+def do_display_document(d, remote_path, page=1):
     """
     Displays the given document on the reader.
     The path must be a valid path on the device.
@@ -109,7 +109,7 @@ def do_dispay_document(d, remote_path, page=1):
     
     Example: dptrp1 display-document Document/Magazines/Comic.pdf 5
     """
-    info = d.list_document_info(remote_path)
+    info = d.list_document_info(add_prefix(remote_path))
     d.display_document(info["entry_id"], page)
 
 
@@ -287,7 +287,7 @@ commands = {
     "update-firmware": do_update_firmware,
     "sync": do_sync,
     "help": do_help,
-    "display-document": do_dispay_document,
+    "display-document": do_display_document,
     "get-configuration": do_get_config,
     "set-configuration": do_set_config,
 }


### PR DESCRIPTION
This is to resolve issue #26. I have added the `Document` prefix to `remote_path` for some commands and tested them on my machine. Let me know if other commands need the prefix too.