### PR TITLE
add a small note about accessing the Fujitsu Quaderno Gen 2 over usb

### DIFF
--- a/docs/linux-ethernet-over-usb.md
+++ b/docs/linux-ethernet-over-usb.md
@@ -62,6 +62,20 @@ The full URI for the DPT-RP1 would be:
 
 This syntax is accepted by urllib3 v1.22 and above.
 
+# Accessing the Fujitsu Quaderno Gen 2 over USB in Linux
 
+The instructions in this guide will work, at the exception of the last part, trying to find the IPv6 local address:
+Instead of `digitalpaper.local`, the Quaderno name is `Android.local`.
 
+    $ avahi-resolve -n Android.local
+    Android.local	fe80::xxxx:xxxx:xxxx:xxxx
+
+Another way to find the device IP address if you don't know the name is to run `avahi-browse`:
+
+	 $ avahi-browse -avr
+	 = usb0 IPv6 Digital Paper FMVDP41                         _dp_fujitsu._tcp     local
+    hostname = [Android.local]
+    address = [fe80::xxxx:xxxx:xxxx:xxxx]
+    port = [8080]
+    txt = []
 


### PR DESCRIPTION
Thank you for this great tool!

It works well with the Quaderno A4 v2 on the latest firmware, even with usb. I followed the instructions  in the [doc](https://github.com/janten/dpt-rp1-py/blob/master/docs/linux-ethernet-over-usb.md). One difference: the name of the device on usb-over-ethernet is Android.local; this is different than the name for the Sony DPT-RP1.

This pull request adds a note to the documentation for future Quaderno users.