### PR TITLE
Avoid deleting a file in the upload command

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -487,20 +487,24 @@ class DigitalPaper:
         self._put_endpoint(doc_url, files=files)
 
     def upload(self, fh, remote_path):
-        # Uploading a document should replace the existing document
-        self.delete_document(remote_path)
         filename = os.path.basename(remote_path)
-        remote_directory = os.path.dirname(remote_path)
-        self.new_folder(remote_directory)
-        directory_id = self._get_object_id(remote_directory)
-        info = {
-            "file_name": filename,
-            "parent_folder_id": directory_id,
-            "document_source": "",
-        }
-        r = self._post_endpoint("/documents2", data=info)
-        doc = r.json()
-        doc_id = doc["document_id"]
+
+        try:
+            # If there exists a document in the specified remote path, overwrite it.
+            doc_id = self._get_object_id(remote_path)
+        except ResolveObjectFailed as e:
+            remote_directory = os.path.dirname(remote_path)
+            self.new_folder(remote_directory)
+            directory_id = self._get_object_id(remote_directory)
+            info = {
+                "file_name": filename,
+                "parent_folder_id": directory_id,
+                "document_source": "",
+            }
+            r = self._post_endpoint("/documents2", data=info)
+            doc = r.json()
+            doc_id = doc["document_id"]
+
         doc_url = "/documents/{doc_id}/file".format(doc_id=doc_id)
 
         files = {"file": (quote_plus(filename), fh, "rb")}


### PR DESCRIPTION
Instead, it now overwrites the existing file. This way, we do not have to reopen the file on the device side after uploading a new file. This behaviour is particularly useful for (proof)reading documents in the middle of writing.