### PR TITLE
Avoid insecure permission

### DIFF
--- a/dptrp1/cli/dptmount.py
+++ b/dptrp1/cli/dptmount.py
@@ -388,7 +388,7 @@ def main():
         tablet,
         args.mountpoint,
         foreground=True,
-        allow_other=True,
+        allow_other=False,
         nothreads=True,
         **kwargs
     )


### PR DESCRIPTION
not allowing ` allow_other` so other users can not read the files.
More importantly, the capabilities of using this option is
disabled in some Linux distribution without root access.