### PR TITLE
Add setuptools dependency for pipx to work

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -45,7 +45,8 @@
         "anytree",
         "fusepy",
         "zeroconf>=0.29.0",
-        "tqdm"
+        "tqdm",
+        "setuptools"
     ],
     "entry_points": {
         "console_scripts": [


### PR DESCRIPTION
If you add `setuptools` as a dependency, then you can use `pipx install dpt-rp1-py`, probably the most convenient way to install `dpt-rp1-py`, if you don't use `dpt-rp1-py` as a library. Otherwise, you have to run additionally `pipx inject dpt-rp1-py setuptools`.