### PR TITLE
fix: issue #25 list-documents not working

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -367,8 +367,8 @@ class DigitalPaper:
         return data['template_list']
 
     def list_documents(self):
-        data = self._get_endpoint("/documents2").json()
-        return data["entry_list"]
+        data = self.traverse_folder_recursively("Document")
+        return data
 
     def list_all(self):
         data = self._get_endpoint("/documents2?entry_type=all").json()


### PR DESCRIPTION
When there are too many documents in the device (apparently more than 1100) the device does not return all documents. This fix uses the method `traverse_folder_recursively()` to take care of this. Apparently, no big performance impacts are noticeable. Fixes issue #25 