### PR TITLE
fix: sync not working for large libraries

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -570,7 +570,7 @@ class DigitalPaper:
         self.set_datetime()
         self.new_folder(remote_folder)
         print("Looking for changes on device... ", end="", flush=True)
-        remote_info = self.traverse_folder_recursively("Document")
+        remote_info = self.traverse_folder_recursively(remote_folder)
         print("done")
 
         # Syncing will require different comparions between local and remote paths.

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -570,9 +570,7 @@ class DigitalPaper:
         self.set_datetime()
         self.new_folder(remote_folder)
         print("Looking for changes on device... ", end="", flush=True)
-        remote_info = self.traverse_folder(
-            remote_folder, fields=["entry_path", "modified_date", "entry_type"]
-        )
+        remote_info = self.traverse_folder_recursively("Document")
         print("done")
 
         # Syncing will require different comparions between local and remote paths.


### PR DESCRIPTION
Hey, I heard you were merging pool requests again, so I'll use the opportunity to throw one myself :)

Similarly as in #25, the sync function fails to retrieve the remote information for large libraries. This commit applies the same fix as in #151, by using the traverse_folder_recursively() method instead of the original traverse_folder() method.

Btw, it is so good that this continues to work with the latest model from Fujitsu. It is working perfectly with the Quaderno G3 color.