### PR TITLE
Fix intermittent registration failures caused by the device's yb sign byte

### DIFF
--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -203,17 +203,25 @@ class DigitalPaper:
 
         n1 = base64.b64decode(m1["a"])
         mac = base64.b64decode(m1["b"])
+        # Keep the device's exact bytes for yb. The DPT-RP1 is a Java device and
+        # builds its own HMACs using yb as BigInteger.toByteArray() produced it,
+        # which prepends a 0x00 sign byte whenever yb's most significant bit is
+        # set -- so yb is 257 bytes, not 256, roughly half the time. Re-encoding
+        # yb to a fixed 256 bytes here makes our HMAC input disagree with the
+        # device precisely in that case, and the device then rejects M2 with
+        # HTTP 403 "Bad parameters for registration process". Using the raw bytes
+        # the device sent always matches its own representation; only the
+        # Diffie-Hellman shared-key computation needs the integer form.
         yb = base64.b64decode(m1["c"])
-        yb = int.from_bytes(yb, "big")
+        yb_int = int.from_bytes(yb, "big")
         n2 = os.urandom(16)  # random nonce
 
         dh = DiffieHellman()
         ya = dh.gen_public_key()
         ya = b"\x00" + ya.to_bytes(256, "big")
 
-        zz = dh.gen_shared_key(yb)
+        zz = dh.gen_shared_key(yb_int)
         zz = zz.to_bytes(256, "big")
-        yb = yb.to_bytes(256, "big")
 
         derivedKey = PBKDF2(
             passphrase=zz, salt=n1 + mac + n2, iterations=10000, digestmodule=SHA256


### PR DESCRIPTION
## Summary

`register()` fails intermittently — roughly half the time — at the `POST /register/hash` (M2) step with:

```
HTTP 403 {"error_code":"40301","message":"Bad parameters for registration process."}
```

The usual workaround is to just run `register` again until it happens to succeed. This PR makes registration reliable on the first attempt.

## Root cause

The DPT-RP1 firmware is Java, and it serializes its Diffie-Hellman public value `yb` with `BigInteger.toByteArray()`. That encoding prepends a `0x00` sign byte whenever the value's most significant bit is set, so **`yb` is 257 bytes about half the time and 256 bytes the other half.**

`register()` receives `yb` as raw bytes but then re-encodes it to a fixed 256 bytes (`yb = yb.to_bytes(256, "big")`) and uses that in three HMACs: the M2 HMAC, `rHash`, and the `eHash` check. The device computes its side of those HMACs using `yb` as *it* serialized it (with the sign byte). So when `yb`'s top bit is set, the client hashes 256 bytes while the device hashed 257, the HMACs disagree, and the device rejects M2. When the top bit is clear, both sides use 256 bytes and registration succeeds — hence the ~50%, seemingly random behavior.

## Fix

Use the exact bytes the device sent for `yb` in the HMACs, and keep an integer form (`yb_int`) only for the Diffie-Hellman shared-key computation. The received bytes always match the device's own representation, whether 256 or 257 bytes, so the HMACs agree every time. `zz` is intentionally left as a fixed 256-byte encoding — only `yb` needed the change.

## Verification

Tested against a physical DPT-RP1 on firmware `1.6.50.14130` over adb:

- Across many handshake attempts, success vs. the 403 correlated **perfectly** with `yb`'s most significant bit (success iff the top bit was clear); the public key's and shared secret's top bits showed no correlation.
- Confirmed the device sends `yb` as 257 bytes precisely when the top bit is set, 256 bytes otherwise.
- With this fix, registration succeeded **16/16** consecutive attempts, covering both the 256- and 257-byte `yb` cases.

Thanks for dpt-rp1-py — the reverse-engineered registration protocol it documents is what made this diagnosis possible; this is just a small robustness fix on top.
