### PR TITLE
Add the support of mooInk Pro 2

### DIFF
--- a/docs/linux-ethernet-over-usb.md
+++ b/docs/linux-ethernet-over-usb.md
@@ -62,10 +62,10 @@ The full URI for the DPT-RP1 would be:
 
 This syntax is accepted by urllib3 v1.22 and above.
 
-# Accessing the Fujitsu Quaderno Gen 2 over USB in Linux
+# Accessing the Fujitsu Quaderno Gen 2 (also Readmoo mooInk Pro 2) over USB in Linux
 
 The instructions in this guide will work, at the exception of the last part, trying to find the IPv6 local address:
-Instead of `digitalpaper.local`, the Quaderno name is `Android.local`.
+Instead of `digitalpaper.local`, the Quaderno/mooInk name is `Android.local`.
 
     $ avahi-resolve -n Android.local
     Android.local	fe80::xxxx:xxxx:xxxx:xxxx

--- a/dptrp1/dptrp1.py
+++ b/dptrp1/dptrp1.py
@@ -126,7 +126,7 @@ class LookUpDPT:
         self.id = id
         zc = Zeroconf()
         self.lock.acquire()
-        ServiceBrowser(zc, ["_digitalpaper._tcp.local.", "_dp_fujitsu._tcp.local."], self)
+        ServiceBrowser(zc, ["_digitalpaper._tcp.local.", "_dp_fujitsu._tcp.local.", "_dp_readmoo._tcp.local."], self)
         wait = self.lock.acquire(timeout=timeout) or (self.addr is not None)
         zc.close()
         if not wait:


### PR DESCRIPTION
Add `_dp_readmoo._tcp.local.` so `dpt-rp1-py` can discover a mooInk Pro 2.

Tested with mooInk Pro 2  (model name: `LSMC3-0001` with version `1.0.26.072906`). 